### PR TITLE
Add option to print paths to result files only

### DIFF
--- a/colcon_test_result/verb/test_result.py
+++ b/colcon_test_result/verb/test_result.py
@@ -40,6 +40,11 @@ class TestResultVerb(VerbExtensionPoint):
             action='store_true',
             help='Show all test result file (even without errors / failures)')
         parser.add_argument(
+            '--result-files-only',
+            action='store_true',
+            help='Print only the path to the result files.'
+                 'Use with --all to get files without errors / failures')
+        parser.add_argument(
             '--verbose',
             action='store_true',
             help='Show additional information for errors / failures')
@@ -52,7 +57,11 @@ class TestResultVerb(VerbExtensionPoint):
         # output stats from individual result files
         for result in results:
             if result.error_count or result.failure_count or context.args.all:
-                print(result)
+                if context.args.result_files_only:
+                    print(result.path)
+                else:
+                    print(result)
+
                 if not context.args.verbose:
                     continue
 


### PR DESCRIPTION
- Implements #16 

## How to test

- In a workspace which has both passing and failing tests:
    - [ ] `colcon test-result --result-files-only` prints the paths of result files with failing tests
    - [ ] `colcon test-result --result-files-only --all` prints the paths to all result files

