### PR TITLE
Fix colcon test-result not counting pytest skips

### DIFF
--- a/colcon_test_result/verb/test_result.py
+++ b/colcon_test_result/verb/test_result.py
@@ -185,6 +185,7 @@ def parse_junit_xml(path, *, get_testcases=False):
         ('error_count', 'errors', 0),
         ('failure_count', 'failures', None),
         ('skipped_count', 'skip', 0),
+        ('skipped_count', 'skipped', 0),
         ('skipped_count', 'disabled', 0),
     ):
         try:


### PR DESCRIPTION
Fixes https://github.com/colcon/colcon-test-result/issues/18

This PR addresses the wrong skipped count for pytests.
This PR **does not** (presently) address the wrong skipped count for gtests skipped with the GTEST_SKIP macro

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>