### PR TITLE
add test result extension point, refactor xUnit logic into an extension

### DIFF
--- a/colcon_test_result/test_result/__init__.py
+++ b/colcon_test_result/test_result/__init__.py
@@ -1,275 +1,18 @@
-# Copyright 2016-2018 Dirk Thomas
+# Copyright 2016-2019 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import argparse
-import os
+from pathlib import Path
 import traceback
-from xml.etree.ElementTree import ElementTree
-from xml.etree.ElementTree import ParseError
 
 from colcon_core.logging import colcon_logger
-from colcon_core.plugin_system import satisfies_version
-from colcon_core.verb import VerbExtensionPoint
+from colcon_core.plugin_system import instantiate_extensions
+from colcon_core.plugin_system import order_extensions_by_name
 
 logger = colcon_logger.getChild(__name__)
 
 
-class TestResultVerb(VerbExtensionPoint):
-    """
-    Collect the jUnit results generated when testing a set of packages.
-
-    It recursively crawls for XML files under the passed build base.
-    Each XML file is being parsed and if it has the structure of a jUnit result
-    file the statistics are being extracted.
-    """
-
-    __test__ = False  # prevent the class to falsely be identified as a test
-
-    def __init__(self):  # noqa: D107
-        super().__init__()
-        satisfies_version(VerbExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
-
-    def add_arguments(self, *, parser):  # noqa: D102
-        parser.add_argument(
-            '--test-result-base',
-            type=_argparse_existing_dir,
-            default='build',
-            help='The base path for all test results (default: build)')
-        parser.add_argument(
-            '--all',
-            action='store_true',
-            help='Show all test result file (even without errors / failures)')
-        parser.add_argument(
-            '--result-files-only',
-            action='store_true',
-            help='Print only the path to the result files.'
-                 'Use with --all to get files without errors / failures')
-        parser.add_argument(
-            '--verbose',
-            action='store_true',
-            help='Show additional information for errors / failures')
-
-    def main(self, *, context):  # noqa: D102
-        results = collect_test_results(
-            context.args.test_result_base,
-            get_testcases=context.args.verbose)
-
-        # output stats from individual result files
-        for result in results:
-            if result.error_count or result.failure_count or context.args.all:
-                if context.args.result_files_only:
-                    print(result.path)
-                else:
-                    print(result)
-
-                if not context.args.verbose:
-                    continue
-
-                for testcase in result.testcases:
-                    if (
-                        not testcase.error_messages and
-                        not testcase.failure_messages
-                    ):
-                        continue
-
-                    # print label of testcase
-                    msg_parts = []
-                    if testcase.classname:
-                        msg_parts.append(testcase.classname)
-                    if testcase.name:
-                        msg_parts.append(testcase.name)
-                    if testcase.file:
-                        suffix = ':' + testcase.line if testcase.line else ''
-                        msg_parts.append(
-                            '({testcase.file}{suffix})'.format_map(locals()))
-                    print('-', ' '.join(msg_parts))
-
-                    # print more information
-                    _output_messages('error message', testcase.error_messages)
-                    _output_messages(
-                        'failure message', testcase.failure_messages)
-                    _output_messages('stdout output', testcase.system_outs)
-                    _output_messages('stderr output', testcase.system_errs)
-
-        if (
-            any(r.error_count or r.failure_count for r in results) or
-            (context.args.all and results)
-        ):
-            print()
-
-        summary = Result('Summary')
-        for result in results:
-            summary.add_result_counts(result)
-
-        print(summary)
-
-        return 1 if summary.error_count or summary.failure_count else 0
-
-
-def _argparse_existing_dir(path):
-    if not os.path.exists(path):
-        raise argparse.ArgumentTypeError("Path '%s' does not exist" % path)
-    if not os.path.isdir(path):
-        raise argparse.ArgumentTypeError("Path '%s' is not a directory" % path)
-    return path
-
-
-def collect_test_results(basepath, *, get_testcases=False):
-    """
-    Collect test results by parsing all XML files in a given path.
-
-    Each file is interpreted as a JUnit result file.
-
-    :param str basepath: the basepath to recursively crawl
-    :returns: list of test results
-    :rtype: list of :py:class:`colcon_core.verb.test_results.Result`
-    """
-    results = []
-    for dirpath, dirnames, filenames in os.walk(str(basepath)):
-        # skip subdirectories starting with a dot
-        dirnames[:] = filter(lambda d: not d.startswith('.'), dirnames)
-        dirnames.sort()
-
-        for filename in sorted(filenames):
-            if not filename.endswith('.xml'):
-                continue
-
-            path = os.path.join(dirpath, filename)
-            try:
-                result = parse_junit_xml(path, get_testcases=get_testcases)
-            except ParseError as e:  # noqa: F841
-                logger.warning("Skipping '{path}': {e}".format_map(locals()))
-                continue
-            except ValueError as e:  # noqa: F841
-                logger.debug("Skipping '{path}': {e}".format_map(locals()))
-                continue
-            except Exception as e:  # noqa: F841
-                exc = traceback.format_exc()
-                logger.error(
-                    "Skipping '{path}': {e}\n{exc}".format_map(locals()))
-                continue
-            results.append(result)
-    return results
-
-
-def parse_junit_xml(path, *, get_testcases=False):
-    """
-    Parse an XML file and interpret it as a jUnit result file.
-
-    See
-    https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#generating-an-xml-report
-    for an example of the format.
-
-    :param str path: the path of the XML file
-    :param parse_testcases: the flag if more information from each test case
-      should be extracted
-    :type parse_testcases: bool
-    :returns: a result containing the stats
-    :rtype: :py:class:`colcon_core.verb.test_results.Result`
-    :raises ParseError: if the XML is not well-formed
-    :raises TypeError: if the root node is neither named 'testsuite' nor
-      'testsuites'
-    """
-    tree = ElementTree()
-    root = tree.parse(path)
-
-    # check if the root tag looks like a jUnit file
-    if root.tag not in ['testsuite', 'testsuites']:
-        raise ValueError(
-            "the root tag is neither 'testsuite' nor 'testsuites'")
-
-    # extract the integer values from various attributes
-    result = Result(path)
-    for slot, attribute, default in (
-        ('test_count', 'tests', None),
-        ('error_count', 'errors', 0),
-        ('failure_count', 'failures', None),
-        ('skipped_count', 'skip', 0),
-        ('skipped_count', 'skipped', 0),
-        ('skipped_count', 'disabled', 0),
-    ):
-        try:
-            value = root.attrib[attribute]
-        except KeyError:
-            if default is None:
-                raise ValueError(
-                    "the '{attribute}' attribute is required"
-                    .format_map(locals()))
-            value = default
-        try:
-            value = int(value)
-        except ValueError:
-            raise ValueError(
-                "the '{attribute}' attribute should be an integer"
-                .format_map(locals()))
-        if value < 0:
-            raise ValueError(
-                "the '{attribute}' attribute should be a positive integer"
-                .format_map(locals()))
-        setattr(result, slot, getattr(result, slot) + value)
-
-    if get_testcases:
-        result.testcases = parse_testcases(root)
-
-    return result
-
-
-def parse_testcases(node):
-    """
-    Parse the statistics of all recursive testcases.
-
-    :param node: The XML node
-    :returns: The testcases
-    :rtype: list
-    """
-    testcases = []
-    # recursively process test suites
-    if node.tag == 'testsuites':
-        for child in node:
-            testcases += parse_testcases(child)
-        return testcases
-
-    if node.tag != 'testsuite':
-        return testcases
-
-    # extract information
-    for child in node:
-        if child.tag != 'testcase':
-            continue
-
-        # extract information from test case
-        testcase = Testcase(
-            classname=child.attrib.get('classname'),
-            file_=child.attrib.get('file'),
-            line=child.attrib.get('line'),
-            name=child.attrib.get('name'),
-            time=child.attrib.get('time'))
-        for child2 in child:
-            if child2.tag == 'error':
-                testcase.error_messages.append(
-                    child2.attrib.get('message', ''))
-            elif child2.tag == 'failure':
-                testcase.failure_messages.append(
-                    child2.attrib.get('message', ''))
-            elif child2.tag == 'system-out':
-                testcase.system_outs.append(child2.text)
-            elif child2.tag == 'system-err':
-                testcase.system_errs.append(child2.text)
-        testcases.append(testcase)
-    return testcases
-
-
-def _output_messages(label, messages):
-    if messages:
-        print(' ', '<<<', label)
-        for message in messages:
-            for line in message.strip('\n\r').splitlines():
-                print(' ', ' ', line)
-        print(' ', '>>>')
-
-
 class Result:
-    """Aggregated statistics from a set of test cases."""
+    """Statistics from a set of tests."""
 
     __slots__ = (
         'path',
@@ -277,7 +20,7 @@ class Result:
         'error_count',
         'failure_count',
         'skipped_count',
-        'testcases',
+        'details',
     )
 
     def __init__(self, path):  # noqa: D107
@@ -286,13 +29,13 @@ class Result:
         self.error_count = 0
         self.failure_count = 0
         self.skipped_count = 0
-        self.testcases = None
+        self.details = []
 
-    def add_result_counts(self, result):
+    def add_result(self, result):
         """
         Add the statistics from another result to this one.
 
-        The `path` and the `testcases` are not changed.
+        The `path` is not changed.
 
         :param result: The other result
         """
@@ -300,6 +43,7 @@ class Result:
         self.error_count += result.error_count
         self.failure_count += result.failure_count
         self.skipped_count += result.skipped_count
+        self.details += result.details
 
     def __str__(self):  # noqa: D105
         data = {}
@@ -316,32 +60,74 @@ class Result:
             .format(**data)
 
 
-class Testcase:
-    """Information from a `testcase` tag."""
+class TestResultExtensionPoint:
+    """
+    The interface for test result extensions.
 
-    __slots__ = (
-        'classname',
-        'file',
-        'line',
-        'name',
-        'time',
-        'error_messages',
-        'failure_messages',
-        'system_outs',
-        'system_errs',
-    )
+    A test result extension provides information about previously run tests.
 
-    __test__ = False  # prevent the class to falsely be identified as a test
+    For each instance the attribute `TEST_RESULT_NAME` is being set
+    to the basename of the entry point registering the extension.
+    """
 
-    def __init__(
-        self, *, classname=None, file_=None, line=None, name=None, time=None
-    ):  # noqa: D107
-        self.classname = classname
-        self.file = file_
-        self.line = line
-        self.name = name
-        self.time = float(time) if time is not None else None
-        self.error_messages = []
-        self.failure_messages = []
-        self.system_outs = []
-        self.system_errs = []
+    """The version of the test result extension interface."""
+    EXTENSION_POINT_VERSION = '1.0'
+
+    def get_test_results(self, basepath, *, collect_details):
+        """
+        Get all test results under the given basepath.
+
+        This method must be overridden in a subclass.
+
+        :param basepath: The basepath to crawl for test results
+        :param collect_details: A flag if details for errors and failures
+          should be collected
+        :returns: A set of Result instances
+        """
+        raise NotImplementedError()
+
+
+def get_test_result_extensions(*, exclude_names=None):
+    """
+    Get the available test result extensions.
+
+    The extensions are ordered by their entry point name.
+
+    :rtype: OrderedDict
+    """
+    extensions = instantiate_extensions(__name__, exclude_names=exclude_names)
+    for name, extension in extensions.items():
+        extension.TEST_RESULT_NAME = name
+    return order_extensions_by_name(extensions)
+
+
+def get_test_results(basepath, *, collect_details):
+    """
+    Get the test results.
+
+    :param basepath: The basepath to collect test results from
+    :param collect_details: A flag if details for errors and failures
+      should be collected
+    :returns: A set of Result instances
+    """
+    extensions = get_test_result_extensions()
+
+    all_test_results = set()
+    for extension in extensions.values():
+        logger.log(1, 'get_test_results(%s)', extension.TEST_RESULT_NAME)
+        try:
+            test_results = extension.get_test_results(
+                Path(basepath), collect_details=collect_details)
+            assert isinstance(test_results, set), \
+                'get_test_results() should return a set'
+        except Exception as e:  # noqa: F841
+            # catch exceptions raised in test result extension
+            exc = traceback.format_exc()
+            logger.error(
+                'Exception in test result extension '
+                "'{extension.TEST_RESULT_NAME}': {e}\n{exc}"
+                .format_map(locals()))
+            # skip failing extension, continue with next one
+            continue
+        all_test_results |= test_results
+    return all_test_results

--- a/colcon_test_result/test_result/__init__.py
+++ b/colcon_test_result/test_result/__init__.py
@@ -1,0 +1,347 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+import os
+import traceback
+from xml.etree.ElementTree import ElementTree
+from xml.etree.ElementTree import ParseError
+
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.verb import VerbExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
+
+
+class TestResultVerb(VerbExtensionPoint):
+    """
+    Collect the jUnit results generated when testing a set of packages.
+
+    It recursively crawls for XML files under the passed build base.
+    Each XML file is being parsed and if it has the structure of a jUnit result
+    file the statistics are being extracted.
+    """
+
+    __test__ = False  # prevent the class to falsely be identified as a test
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(VerbExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        parser.add_argument(
+            '--test-result-base',
+            type=_argparse_existing_dir,
+            default='build',
+            help='The base path for all test results (default: build)')
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Show all test result file (even without errors / failures)')
+        parser.add_argument(
+            '--result-files-only',
+            action='store_true',
+            help='Print only the path to the result files.'
+                 'Use with --all to get files without errors / failures')
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            help='Show additional information for errors / failures')
+
+    def main(self, *, context):  # noqa: D102
+        results = collect_test_results(
+            context.args.test_result_base,
+            get_testcases=context.args.verbose)
+
+        # output stats from individual result files
+        for result in results:
+            if result.error_count or result.failure_count or context.args.all:
+                if context.args.result_files_only:
+                    print(result.path)
+                else:
+                    print(result)
+
+                if not context.args.verbose:
+                    continue
+
+                for testcase in result.testcases:
+                    if (
+                        not testcase.error_messages and
+                        not testcase.failure_messages
+                    ):
+                        continue
+
+                    # print label of testcase
+                    msg_parts = []
+                    if testcase.classname:
+                        msg_parts.append(testcase.classname)
+                    if testcase.name:
+                        msg_parts.append(testcase.name)
+                    if testcase.file:
+                        suffix = ':' + testcase.line if testcase.line else ''
+                        msg_parts.append(
+                            '({testcase.file}{suffix})'.format_map(locals()))
+                    print('-', ' '.join(msg_parts))
+
+                    # print more information
+                    _output_messages('error message', testcase.error_messages)
+                    _output_messages(
+                        'failure message', testcase.failure_messages)
+                    _output_messages('stdout output', testcase.system_outs)
+                    _output_messages('stderr output', testcase.system_errs)
+
+        if (
+            any(r.error_count or r.failure_count for r in results) or
+            (context.args.all and results)
+        ):
+            print()
+
+        summary = Result('Summary')
+        for result in results:
+            summary.add_result_counts(result)
+
+        print(summary)
+
+        return 1 if summary.error_count or summary.failure_count else 0
+
+
+def _argparse_existing_dir(path):
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError("Path '%s' does not exist" % path)
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError("Path '%s' is not a directory" % path)
+    return path
+
+
+def collect_test_results(basepath, *, get_testcases=False):
+    """
+    Collect test results by parsing all XML files in a given path.
+
+    Each file is interpreted as a JUnit result file.
+
+    :param str basepath: the basepath to recursively crawl
+    :returns: list of test results
+    :rtype: list of :py:class:`colcon_core.verb.test_results.Result`
+    """
+    results = []
+    for dirpath, dirnames, filenames in os.walk(str(basepath)):
+        # skip subdirectories starting with a dot
+        dirnames[:] = filter(lambda d: not d.startswith('.'), dirnames)
+        dirnames.sort()
+
+        for filename in sorted(filenames):
+            if not filename.endswith('.xml'):
+                continue
+
+            path = os.path.join(dirpath, filename)
+            try:
+                result = parse_junit_xml(path, get_testcases=get_testcases)
+            except ParseError as e:  # noqa: F841
+                logger.warning("Skipping '{path}': {e}".format_map(locals()))
+                continue
+            except ValueError as e:  # noqa: F841
+                logger.debug("Skipping '{path}': {e}".format_map(locals()))
+                continue
+            except Exception as e:  # noqa: F841
+                exc = traceback.format_exc()
+                logger.error(
+                    "Skipping '{path}': {e}\n{exc}".format_map(locals()))
+                continue
+            results.append(result)
+    return results
+
+
+def parse_junit_xml(path, *, get_testcases=False):
+    """
+    Parse an XML file and interpret it as a jUnit result file.
+
+    See
+    https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#generating-an-xml-report
+    for an example of the format.
+
+    :param str path: the path of the XML file
+    :param parse_testcases: the flag if more information from each test case
+      should be extracted
+    :type parse_testcases: bool
+    :returns: a result containing the stats
+    :rtype: :py:class:`colcon_core.verb.test_results.Result`
+    :raises ParseError: if the XML is not well-formed
+    :raises TypeError: if the root node is neither named 'testsuite' nor
+      'testsuites'
+    """
+    tree = ElementTree()
+    root = tree.parse(path)
+
+    # check if the root tag looks like a jUnit file
+    if root.tag not in ['testsuite', 'testsuites']:
+        raise ValueError(
+            "the root tag is neither 'testsuite' nor 'testsuites'")
+
+    # extract the integer values from various attributes
+    result = Result(path)
+    for slot, attribute, default in (
+        ('test_count', 'tests', None),
+        ('error_count', 'errors', 0),
+        ('failure_count', 'failures', None),
+        ('skipped_count', 'skip', 0),
+        ('skipped_count', 'skipped', 0),
+        ('skipped_count', 'disabled', 0),
+    ):
+        try:
+            value = root.attrib[attribute]
+        except KeyError:
+            if default is None:
+                raise ValueError(
+                    "the '{attribute}' attribute is required"
+                    .format_map(locals()))
+            value = default
+        try:
+            value = int(value)
+        except ValueError:
+            raise ValueError(
+                "the '{attribute}' attribute should be an integer"
+                .format_map(locals()))
+        if value < 0:
+            raise ValueError(
+                "the '{attribute}' attribute should be a positive integer"
+                .format_map(locals()))
+        setattr(result, slot, getattr(result, slot) + value)
+
+    if get_testcases:
+        result.testcases = parse_testcases(root)
+
+    return result
+
+
+def parse_testcases(node):
+    """
+    Parse the statistics of all recursive testcases.
+
+    :param node: The XML node
+    :returns: The testcases
+    :rtype: list
+    """
+    testcases = []
+    # recursively process test suites
+    if node.tag == 'testsuites':
+        for child in node:
+            testcases += parse_testcases(child)
+        return testcases
+
+    if node.tag != 'testsuite':
+        return testcases
+
+    # extract information
+    for child in node:
+        if child.tag != 'testcase':
+            continue
+
+        # extract information from test case
+        testcase = Testcase(
+            classname=child.attrib.get('classname'),
+            file_=child.attrib.get('file'),
+            line=child.attrib.get('line'),
+            name=child.attrib.get('name'),
+            time=child.attrib.get('time'))
+        for child2 in child:
+            if child2.tag == 'error':
+                testcase.error_messages.append(
+                    child2.attrib.get('message', ''))
+            elif child2.tag == 'failure':
+                testcase.failure_messages.append(
+                    child2.attrib.get('message', ''))
+            elif child2.tag == 'system-out':
+                testcase.system_outs.append(child2.text)
+            elif child2.tag == 'system-err':
+                testcase.system_errs.append(child2.text)
+        testcases.append(testcase)
+    return testcases
+
+
+def _output_messages(label, messages):
+    if messages:
+        print(' ', '<<<', label)
+        for message in messages:
+            for line in message.strip('\n\r').splitlines():
+                print(' ', ' ', line)
+        print(' ', '>>>')
+
+
+class Result:
+    """Aggregated statistics from a set of test cases."""
+
+    __slots__ = (
+        'path',
+        'test_count',
+        'error_count',
+        'failure_count',
+        'skipped_count',
+        'testcases',
+    )
+
+    def __init__(self, path):  # noqa: D107
+        self.path = path
+        self.test_count = 0
+        self.error_count = 0
+        self.failure_count = 0
+        self.skipped_count = 0
+        self.testcases = None
+
+    def add_result_counts(self, result):
+        """
+        Add the statistics from another result to this one.
+
+        The `path` and the `testcases` are not changed.
+
+        :param result: The other result
+        """
+        self.test_count += result.test_count
+        self.error_count += result.error_count
+        self.failure_count += result.failure_count
+        self.skipped_count += result.skipped_count
+
+    def __str__(self):  # noqa: D105
+        data = {}
+        for slot in self.__slots__:
+            data[slot] = getattr(self, slot)
+            if slot in ('test_count', 'error_count', 'failure_count'):
+                data[slot + '_plural'] = 's' if data[slot] != 1 else ''
+        return \
+            '{path}: ' \
+            '{test_count} test{test_count_plural}, ' \
+            '{error_count} error{error_count_plural}, ' \
+            '{failure_count} failure{failure_count_plural}, ' \
+            '{skipped_count} skipped' \
+            .format(**data)
+
+
+class Testcase:
+    """Information from a `testcase` tag."""
+
+    __slots__ = (
+        'classname',
+        'file',
+        'line',
+        'name',
+        'time',
+        'error_messages',
+        'failure_messages',
+        'system_outs',
+        'system_errs',
+    )
+
+    __test__ = False  # prevent the class to falsely be identified as a test
+
+    def __init__(
+        self, *, classname=None, file_=None, line=None, name=None, time=None
+    ):  # noqa: D107
+        self.classname = classname
+        self.file = file_
+        self.line = line
+        self.name = name
+        self.time = float(time) if time is not None else None
+        self.error_messages = []
+        self.failure_messages = []
+        self.system_outs = []
+        self.system_errs = []

--- a/colcon_test_result/test_result/xunit.py
+++ b/colcon_test_result/test_result/xunit.py
@@ -1,0 +1,347 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+import os
+import traceback
+from xml.etree.ElementTree import ElementTree
+from xml.etree.ElementTree import ParseError
+
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.verb import VerbExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
+
+
+class TestResultVerb(VerbExtensionPoint):
+    """
+    Collect the jUnit results generated when testing a set of packages.
+
+    It recursively crawls for XML files under the passed build base.
+    Each XML file is being parsed and if it has the structure of a jUnit result
+    file the statistics are being extracted.
+    """
+
+    __test__ = False  # prevent the class to falsely be identified as a test
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(VerbExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        parser.add_argument(
+            '--test-result-base',
+            type=_argparse_existing_dir,
+            default='build',
+            help='The base path for all test results (default: build)')
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Show all test result file (even without errors / failures)')
+        parser.add_argument(
+            '--result-files-only',
+            action='store_true',
+            help='Print only the path to the result files.'
+                 'Use with --all to get files without errors / failures')
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            help='Show additional information for errors / failures')
+
+    def main(self, *, context):  # noqa: D102
+        results = collect_test_results(
+            context.args.test_result_base,
+            get_testcases=context.args.verbose)
+
+        # output stats from individual result files
+        for result in results:
+            if result.error_count or result.failure_count or context.args.all:
+                if context.args.result_files_only:
+                    print(result.path)
+                else:
+                    print(result)
+
+                if not context.args.verbose:
+                    continue
+
+                for testcase in result.testcases:
+                    if (
+                        not testcase.error_messages and
+                        not testcase.failure_messages
+                    ):
+                        continue
+
+                    # print label of testcase
+                    msg_parts = []
+                    if testcase.classname:
+                        msg_parts.append(testcase.classname)
+                    if testcase.name:
+                        msg_parts.append(testcase.name)
+                    if testcase.file:
+                        suffix = ':' + testcase.line if testcase.line else ''
+                        msg_parts.append(
+                            '({testcase.file}{suffix})'.format_map(locals()))
+                    print('-', ' '.join(msg_parts))
+
+                    # print more information
+                    _output_messages('error message', testcase.error_messages)
+                    _output_messages(
+                        'failure message', testcase.failure_messages)
+                    _output_messages('stdout output', testcase.system_outs)
+                    _output_messages('stderr output', testcase.system_errs)
+
+        if (
+            any(r.error_count or r.failure_count for r in results) or
+            (context.args.all and results)
+        ):
+            print()
+
+        summary = Result('Summary')
+        for result in results:
+            summary.add_result_counts(result)
+
+        print(summary)
+
+        return 1 if summary.error_count or summary.failure_count else 0
+
+
+def _argparse_existing_dir(path):
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError("Path '%s' does not exist" % path)
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError("Path '%s' is not a directory" % path)
+    return path
+
+
+def collect_test_results(basepath, *, get_testcases=False):
+    """
+    Collect test results by parsing all XML files in a given path.
+
+    Each file is interpreted as a JUnit result file.
+
+    :param str basepath: the basepath to recursively crawl
+    :returns: list of test results
+    :rtype: list of :py:class:`colcon_core.verb.test_results.Result`
+    """
+    results = []
+    for dirpath, dirnames, filenames in os.walk(str(basepath)):
+        # skip subdirectories starting with a dot
+        dirnames[:] = filter(lambda d: not d.startswith('.'), dirnames)
+        dirnames.sort()
+
+        for filename in sorted(filenames):
+            if not filename.endswith('.xml'):
+                continue
+
+            path = os.path.join(dirpath, filename)
+            try:
+                result = parse_junit_xml(path, get_testcases=get_testcases)
+            except ParseError as e:  # noqa: F841
+                logger.warning("Skipping '{path}': {e}".format_map(locals()))
+                continue
+            except ValueError as e:  # noqa: F841
+                logger.debug("Skipping '{path}': {e}".format_map(locals()))
+                continue
+            except Exception as e:  # noqa: F841
+                exc = traceback.format_exc()
+                logger.error(
+                    "Skipping '{path}': {e}\n{exc}".format_map(locals()))
+                continue
+            results.append(result)
+    return results
+
+
+def parse_junit_xml(path, *, get_testcases=False):
+    """
+    Parse an XML file and interpret it as a jUnit result file.
+
+    See
+    https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#generating-an-xml-report
+    for an example of the format.
+
+    :param str path: the path of the XML file
+    :param parse_testcases: the flag if more information from each test case
+      should be extracted
+    :type parse_testcases: bool
+    :returns: a result containing the stats
+    :rtype: :py:class:`colcon_core.verb.test_results.Result`
+    :raises ParseError: if the XML is not well-formed
+    :raises TypeError: if the root node is neither named 'testsuite' nor
+      'testsuites'
+    """
+    tree = ElementTree()
+    root = tree.parse(path)
+
+    # check if the root tag looks like a jUnit file
+    if root.tag not in ['testsuite', 'testsuites']:
+        raise ValueError(
+            "the root tag is neither 'testsuite' nor 'testsuites'")
+
+    # extract the integer values from various attributes
+    result = Result(path)
+    for slot, attribute, default in (
+        ('test_count', 'tests', None),
+        ('error_count', 'errors', 0),
+        ('failure_count', 'failures', None),
+        ('skipped_count', 'skip', 0),
+        ('skipped_count', 'skipped', 0),
+        ('skipped_count', 'disabled', 0),
+    ):
+        try:
+            value = root.attrib[attribute]
+        except KeyError:
+            if default is None:
+                raise ValueError(
+                    "the '{attribute}' attribute is required"
+                    .format_map(locals()))
+            value = default
+        try:
+            value = int(value)
+        except ValueError:
+            raise ValueError(
+                "the '{attribute}' attribute should be an integer"
+                .format_map(locals()))
+        if value < 0:
+            raise ValueError(
+                "the '{attribute}' attribute should be a positive integer"
+                .format_map(locals()))
+        setattr(result, slot, getattr(result, slot) + value)
+
+    if get_testcases:
+        result.testcases = parse_testcases(root)
+
+    return result
+
+
+def parse_testcases(node):
+    """
+    Parse the statistics of all recursive testcases.
+
+    :param node: The XML node
+    :returns: The testcases
+    :rtype: list
+    """
+    testcases = []
+    # recursively process test suites
+    if node.tag == 'testsuites':
+        for child in node:
+            testcases += parse_testcases(child)
+        return testcases
+
+    if node.tag != 'testsuite':
+        return testcases
+
+    # extract information
+    for child in node:
+        if child.tag != 'testcase':
+            continue
+
+        # extract information from test case
+        testcase = Testcase(
+            classname=child.attrib.get('classname'),
+            file_=child.attrib.get('file'),
+            line=child.attrib.get('line'),
+            name=child.attrib.get('name'),
+            time=child.attrib.get('time'))
+        for child2 in child:
+            if child2.tag == 'error':
+                testcase.error_messages.append(
+                    child2.attrib.get('message', ''))
+            elif child2.tag == 'failure':
+                testcase.failure_messages.append(
+                    child2.attrib.get('message', ''))
+            elif child2.tag == 'system-out':
+                testcase.system_outs.append(child2.text)
+            elif child2.tag == 'system-err':
+                testcase.system_errs.append(child2.text)
+        testcases.append(testcase)
+    return testcases
+
+
+def _output_messages(label, messages):
+    if messages:
+        print(' ', '<<<', label)
+        for message in messages:
+            for line in message.strip('\n\r').splitlines():
+                print(' ', ' ', line)
+        print(' ', '>>>')
+
+
+class Result:
+    """Aggregated statistics from a set of test cases."""
+
+    __slots__ = (
+        'path',
+        'test_count',
+        'error_count',
+        'failure_count',
+        'skipped_count',
+        'testcases',
+    )
+
+    def __init__(self, path):  # noqa: D107
+        self.path = path
+        self.test_count = 0
+        self.error_count = 0
+        self.failure_count = 0
+        self.skipped_count = 0
+        self.testcases = None
+
+    def add_result_counts(self, result):
+        """
+        Add the statistics from another result to this one.
+
+        The `path` and the `testcases` are not changed.
+
+        :param result: The other result
+        """
+        self.test_count += result.test_count
+        self.error_count += result.error_count
+        self.failure_count += result.failure_count
+        self.skipped_count += result.skipped_count
+
+    def __str__(self):  # noqa: D105
+        data = {}
+        for slot in self.__slots__:
+            data[slot] = getattr(self, slot)
+            if slot in ('test_count', 'error_count', 'failure_count'):
+                data[slot + '_plural'] = 's' if data[slot] != 1 else ''
+        return \
+            '{path}: ' \
+            '{test_count} test{test_count_plural}, ' \
+            '{error_count} error{error_count_plural}, ' \
+            '{failure_count} failure{failure_count_plural}, ' \
+            '{skipped_count} skipped' \
+            .format(**data)
+
+
+class Testcase:
+    """Information from a `testcase` tag."""
+
+    __slots__ = (
+        'classname',
+        'file',
+        'line',
+        'name',
+        'time',
+        'error_messages',
+        'failure_messages',
+        'system_outs',
+        'system_errs',
+    )
+
+    __test__ = False  # prevent the class to falsely be identified as a test
+
+    def __init__(
+        self, *, classname=None, file_=None, line=None, name=None, time=None
+    ):  # noqa: D107
+        self.classname = classname
+        self.file = file_
+        self.line = line
+        self.name = name
+        self.time = float(time) if time is not None else None
+        self.error_messages = []
+        self.failure_messages = []
+        self.system_outs = []
+        self.system_errs = []

--- a/colcon_test_result/verb/test_result.py
+++ b/colcon_test_result/verb/test_result.py
@@ -1,27 +1,20 @@
-# Copyright 2016-2018 Dirk Thomas
+# Copyright 2016-2019 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
 import argparse
 import os
-import traceback
-from xml.etree.ElementTree import ElementTree
-from xml.etree.ElementTree import ParseError
 
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.verb import VerbExtensionPoint
+from colcon_test_result.test_result import get_test_results
+from colcon_test_result.test_result import Result
 
 logger = colcon_logger.getChild(__name__)
 
 
 class TestResultVerb(VerbExtensionPoint):
-    """
-    Collect the jUnit results generated when testing a set of packages.
-
-    It recursively crawls for XML files under the passed build base.
-    Each XML file is being parsed and if it has the structure of a jUnit result
-    file the statistics are being extracted.
-    """
+    """Show the test results generated when testing a set of packages."""
 
     __test__ = False  # prevent the class to falsely be identified as a test
 
@@ -50,46 +43,24 @@ class TestResultVerb(VerbExtensionPoint):
             help='Show additional information for errors / failures')
 
     def main(self, *, context):  # noqa: D102
-        results = collect_test_results(
+        results = get_test_results(
             context.args.test_result_base,
-            get_testcases=context.args.verbose)
+            collect_details=context.args.verbose)
+
+        result_tuples = [(r.path, r) for r in results]
 
         # output stats from individual result files
-        for result in results:
+        for _, result in sorted(result_tuples):
             if result.error_count or result.failure_count or context.args.all:
                 if context.args.result_files_only:
                     print(result.path)
                 else:
                     print(result)
 
-                if not context.args.verbose:
-                    continue
-
-                for testcase in result.testcases:
-                    if (
-                        not testcase.error_messages and
-                        not testcase.failure_messages
-                    ):
-                        continue
-
-                    # print label of testcase
-                    msg_parts = []
-                    if testcase.classname:
-                        msg_parts.append(testcase.classname)
-                    if testcase.name:
-                        msg_parts.append(testcase.name)
-                    if testcase.file:
-                        suffix = ':' + testcase.line if testcase.line else ''
-                        msg_parts.append(
-                            '({testcase.file}{suffix})'.format_map(locals()))
-                    print('-', ' '.join(msg_parts))
-
-                    # print more information
-                    _output_messages('error message', testcase.error_messages)
-                    _output_messages(
-                        'failure message', testcase.failure_messages)
-                    _output_messages('stdout output', testcase.system_outs)
-                    _output_messages('stderr output', testcase.system_errs)
+                if context.args.verbose:
+                    for detail in result.details:
+                        for i, line in enumerate(detail.splitlines()):
+                            print('-' if i == 0 else ' ', line)
 
         if (
             any(r.error_count or r.failure_count for r in results) or
@@ -99,7 +70,7 @@ class TestResultVerb(VerbExtensionPoint):
 
         summary = Result('Summary')
         for result in results:
-            summary.add_result_counts(result)
+            summary.add_result(result)
 
         print(summary)
 
@@ -112,236 +83,3 @@ def _argparse_existing_dir(path):
     if not os.path.isdir(path):
         raise argparse.ArgumentTypeError("Path '%s' is not a directory" % path)
     return path
-
-
-def collect_test_results(basepath, *, get_testcases=False):
-    """
-    Collect test results by parsing all XML files in a given path.
-
-    Each file is interpreted as a JUnit result file.
-
-    :param str basepath: the basepath to recursively crawl
-    :returns: list of test results
-    :rtype: list of :py:class:`colcon_core.verb.test_results.Result`
-    """
-    results = []
-    for dirpath, dirnames, filenames in os.walk(str(basepath)):
-        # skip subdirectories starting with a dot
-        dirnames[:] = filter(lambda d: not d.startswith('.'), dirnames)
-        dirnames.sort()
-
-        for filename in sorted(filenames):
-            if not filename.endswith('.xml'):
-                continue
-
-            path = os.path.join(dirpath, filename)
-            try:
-                result = parse_junit_xml(path, get_testcases=get_testcases)
-            except ParseError as e:  # noqa: F841
-                logger.warning("Skipping '{path}': {e}".format_map(locals()))
-                continue
-            except ValueError as e:  # noqa: F841
-                logger.debug("Skipping '{path}': {e}".format_map(locals()))
-                continue
-            except Exception as e:  # noqa: F841
-                exc = traceback.format_exc()
-                logger.error(
-                    "Skipping '{path}': {e}\n{exc}".format_map(locals()))
-                continue
-            results.append(result)
-    return results
-
-
-def parse_junit_xml(path, *, get_testcases=False):
-    """
-    Parse an XML file and interpret it as a jUnit result file.
-
-    See
-    https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#generating-an-xml-report
-    for an example of the format.
-
-    :param str path: the path of the XML file
-    :param parse_testcases: the flag if more information from each test case
-      should be extracted
-    :type parse_testcases: bool
-    :returns: a result containing the stats
-    :rtype: :py:class:`colcon_core.verb.test_results.Result`
-    :raises ParseError: if the XML is not well-formed
-    :raises TypeError: if the root node is neither named 'testsuite' nor
-      'testsuites'
-    """
-    tree = ElementTree()
-    root = tree.parse(path)
-
-    # check if the root tag looks like a jUnit file
-    if root.tag not in ['testsuite', 'testsuites']:
-        raise ValueError(
-            "the root tag is neither 'testsuite' nor 'testsuites'")
-
-    # extract the integer values from various attributes
-    result = Result(path)
-    for slot, attribute, default in (
-        ('test_count', 'tests', None),
-        ('error_count', 'errors', 0),
-        ('failure_count', 'failures', None),
-        ('skipped_count', 'skip', 0),
-        ('skipped_count', 'skipped', 0),
-        ('skipped_count', 'disabled', 0),
-    ):
-        try:
-            value = root.attrib[attribute]
-        except KeyError:
-            if default is None:
-                raise ValueError(
-                    "the '{attribute}' attribute is required"
-                    .format_map(locals()))
-            value = default
-        try:
-            value = int(value)
-        except ValueError:
-            raise ValueError(
-                "the '{attribute}' attribute should be an integer"
-                .format_map(locals()))
-        if value < 0:
-            raise ValueError(
-                "the '{attribute}' attribute should be a positive integer"
-                .format_map(locals()))
-        setattr(result, slot, getattr(result, slot) + value)
-
-    if get_testcases:
-        result.testcases = parse_testcases(root)
-
-    return result
-
-
-def parse_testcases(node):
-    """
-    Parse the statistics of all recursive testcases.
-
-    :param node: The XML node
-    :returns: The testcases
-    :rtype: list
-    """
-    testcases = []
-    # recursively process test suites
-    if node.tag == 'testsuites':
-        for child in node:
-            testcases += parse_testcases(child)
-        return testcases
-
-    if node.tag != 'testsuite':
-        return testcases
-
-    # extract information
-    for child in node:
-        if child.tag != 'testcase':
-            continue
-
-        # extract information from test case
-        testcase = Testcase(
-            classname=child.attrib.get('classname'),
-            file_=child.attrib.get('file'),
-            line=child.attrib.get('line'),
-            name=child.attrib.get('name'),
-            time=child.attrib.get('time'))
-        for child2 in child:
-            if child2.tag == 'error':
-                testcase.error_messages.append(
-                    child2.attrib.get('message', ''))
-            elif child2.tag == 'failure':
-                testcase.failure_messages.append(
-                    child2.attrib.get('message', ''))
-            elif child2.tag == 'system-out':
-                testcase.system_outs.append(child2.text)
-            elif child2.tag == 'system-err':
-                testcase.system_errs.append(child2.text)
-        testcases.append(testcase)
-    return testcases
-
-
-def _output_messages(label, messages):
-    if messages:
-        print(' ', '<<<', label)
-        for message in messages:
-            for line in message.strip('\n\r').splitlines():
-                print(' ', ' ', line)
-        print(' ', '>>>')
-
-
-class Result:
-    """Aggregated statistics from a set of test cases."""
-
-    __slots__ = (
-        'path',
-        'test_count',
-        'error_count',
-        'failure_count',
-        'skipped_count',
-        'testcases',
-    )
-
-    def __init__(self, path):  # noqa: D107
-        self.path = path
-        self.test_count = 0
-        self.error_count = 0
-        self.failure_count = 0
-        self.skipped_count = 0
-        self.testcases = None
-
-    def add_result_counts(self, result):
-        """
-        Add the statistics from another result to this one.
-
-        The `path` and the `testcases` are not changed.
-
-        :param result: The other result
-        """
-        self.test_count += result.test_count
-        self.error_count += result.error_count
-        self.failure_count += result.failure_count
-        self.skipped_count += result.skipped_count
-
-    def __str__(self):  # noqa: D105
-        data = {}
-        for slot in self.__slots__:
-            data[slot] = getattr(self, slot)
-            if slot in ('test_count', 'error_count', 'failure_count'):
-                data[slot + '_plural'] = 's' if data[slot] != 1 else ''
-        return \
-            '{path}: ' \
-            '{test_count} test{test_count_plural}, ' \
-            '{error_count} error{error_count_plural}, ' \
-            '{failure_count} failure{failure_count_plural}, ' \
-            '{skipped_count} skipped' \
-            .format(**data)
-
-
-class Testcase:
-    """Information from a `testcase` tag."""
-
-    __slots__ = (
-        'classname',
-        'file',
-        'line',
-        'name',
-        'time',
-        'error_messages',
-        'failure_messages',
-        'system_outs',
-        'system_errs',
-    )
-
-    __test__ = False  # prevent the class to falsely be identified as a test
-
-    def __init__(
-        self, *, classname=None, file_=None, line=None, name=None, time=None
-    ):  # noqa: D107
-        self.classname = classname
-        self.file = file_
-        self.line = line
-        self.name = name
-        self.time = float(time) if time is not None else None
-        self.error_messages = []
-        self.failure_messages = []
-        self.system_outs = []
-        self.system_errs = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,12 @@ filterwarnings =
 junit_suite_name = colcon-test-result
 
 [options.entry_points]
+colcon_core.extension_point =
+    colcon_test_result.test_result = colcon_test_result.test_result:TestResultExtensionPoint
 colcon_core.verb =
     test-result = colcon_test_result.verb.test_result:TestResultVerb
+colcon_test_result.test_result =
+    xunit = colcon_test_result.test_result.xunit:XunitTestResult
 
 [flake8]
 import-order-style = google

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,7 +9,6 @@ google
 googletest
 https
 iterdir
-junit
 noqa
 pathlib
 plugin
@@ -23,3 +22,5 @@ testsuite
 testsuites
 thomas
 traceback
+tuples
+xunit


### PR DESCRIPTION
The existing functionality as well as output format is maintained. The change enables to write extensions to provide test results from different sources.