### PR TITLE
Do not print summary when using --result-files-only

### DIFF
--- a/colcon_test_result/verb/test_result.py
+++ b/colcon_test_result/verb/test_result.py
@@ -72,7 +72,8 @@ class TestResultVerb(VerbExtensionPoint):
         for result in results:
             summary.add_result(result)
 
-        print(summary)
+        if not context.args.result_files_only:
+            print(summary)
 
         return 1 if summary.error_count or summary.failure_count else 0
 


### PR DESCRIPTION
The option is meant to enable workflows where it's
necessary to pipe the list of results into other
programs, so the summary isn't really relevant

Follow up from: https://github.com/colcon/colcon-test-result/pull/17#issuecomment-483432181
